### PR TITLE
Update the globally referenced Docker Hub repository

### DIFF
--- a/bugswarm/common/credentials.py
+++ b/bugswarm/common/credentials.py
@@ -1,3 +1,3 @@
 # DockerHub
 DOCKER_HUB_USERNAME = 'bugswarm'
-DOCKER_HUB_REPO = '{}/{}'.format(DOCKER_HUB_USERNAME, 'artifacts')
+DOCKER_HUB_REPO = '{}/{}'.format(DOCKER_HUB_USERNAME, 'images')


### PR DESCRIPTION
@Teptphanyaki @dtomassi
Please take a look at and review this PR when you get a chance.

The BugSwarm infrastructure currently references to the `bugswarm/artifacts` Docker Hub repository. This change updates the constant that determines the Docker Hub repository that is referenced by the rest of the BugSwarm infrastructure.

After this change is incorporated, `reproducer` (specifically, `packager`) will push new Docker images to the `bugswarm/images` Docker Hub repository and the BugSwarm client will pull from the `bugswarm/images` Docker Hub repository. Also, the metadata browser on the website will point to the new repository as well.