### PR TITLE
Fix Database API - set artifact patches

### DIFF
--- a/bugswarm/common/rest_api/database_api.py
+++ b/bugswarm/common/rest_api/database_api.py
@@ -144,7 +144,7 @@ class DatabaseAPI(object):
         updates = {'passed_job.config': config}
         return self._patch(DatabaseAPI._artifact_image_tag_endpoint(image_tag), updates)
 
-    def set_artifact_failed_patch(self, image_tag: str, patch_name: str, patch) -> Response:
+    def set_artifact_failed_patch(self, image_tag: str, patch_name: str) -> Response:
         """
         Add the patch for the artifact to an existing artifact's failed job metadata.
 
@@ -170,7 +170,7 @@ class DatabaseAPI(object):
         updates = {'failed_job.patches': patches_list}
         return self._patch(DatabaseAPI._artifact_image_tag_endpoint(image_tag), updates)
 
-    def set_artifact_passed_patch(self, image_tag: str, patch_name: str, patch) -> Response:
+    def set_artifact_passed_patch(self, image_tag: str, patch_name: str) -> Response:
         """
         Add the patch for the artifact to an existing artifact's passed job metadata.
 


### PR DESCRIPTION
In `artifact_schema`, the `patches` is a list instead of dictionary.
