### PR TITLE
rename build_system to job_pairs

### DIFF
--- a/bugswarm/common/rest_api/database_api.py
+++ b/bugswarm/common/rest_api/database_api.py
@@ -220,7 +220,7 @@ class DatabaseAPI(object):
     ###################################
     # Mined Build Pair REST methods
     ###################################
-    def patch_build_system(self, obj_id: str, job_pairs) -> Response:
+    def patch_job_pairs(self, obj_id: str, job_pairs) -> Response:
         updates = {'jobpairs': job_pairs}
         return self._patch(DatabaseAPI._mined_build_pair_object_id_endpoint(obj_id), updates)
 


### PR DESCRIPTION
Originally this api is for patch build system. Now we also want to use it when patching `tr_num_test_failed` (BugSwarm/classification#7)
`patch_job_pairs` is more appropriate.
