### PR TITLE
Fix mutate when iterating

### DIFF
--- a/bugswarm/common/github_wrapper.py
+++ b/bugswarm/common/github_wrapper.py
@@ -160,7 +160,7 @@ class GitHubWrapper(object):
                 chosen_token = t
                 min_wait_time = 0
                 # if a token is chosen, move it to the end
-                updated_toekn.append(t)
+                updated_token.append(t)
                 del updated_token[updated_token.index(t)]
                 break
             if wait_time < min_wait_time:


### PR DESCRIPTION
## Problem
At running time, mutating while iterating err would occur.
## Fix
mutate an deep copy of deque and assign it back at the end of loop. 
Python garbage collection (reference counting) will clean up the additional deep copy